### PR TITLE
Fix frame title for frames with allowframebreak

### DIFF
--- a/head.tex
+++ b/head.tex
@@ -1,4 +1,6 @@
-
+\usepackage[absolute,overlay]{textpos}
+\setlength{\TPHorizModule}{\paperwidth}
+\setlength{\TPHorizModule}{\paperheight}
 % --- Header
 \setbeamertemplate{frametitle}{
   \leavevmode

--- a/vortrag.tex
+++ b/vortrag.tex
@@ -1,7 +1,8 @@
 % Page Layout
 \documentclass[12pt,slidestop]{beamer}
-\include{head}
+\usepackage{etex} % Avoid an error due to a lack of registers
 \include{layout}
+\include{head}
 
 \title[ShortTitle]{LongTitle}
 \author[ShortAuthor]{LongAuthor}


### PR DESCRIPTION
Use \setbeamertemplate instead of redefining \frametitle
